### PR TITLE
fix: Web Speech API timeout and duplicate transcription bugs (#13)

### DIFF
--- a/.artifacts/tdd-cycle-status.md
+++ b/.artifacts/tdd-cycle-status.md
@@ -314,3 +314,52 @@ Tests run: 6
 Failed: 0
 Overall: PASS → ready for next
 
+
+## 2026年  2月 28日 土曜日 16:46:15 JST
+File: src/hooks/useAudio.test.ts
+Phase: RED
+Tests run: 3
+Failed: 2
+Overall: FAIL → fix required
+
+## 2026年  2月 28日 土曜日 16:46:40 JST
+File: src/hooks/useAudio.ts
+Phase: GREEN
+Tests run: 3
+Failed: 0
+Overall: PASS → ready for next
+
+## 2026年  2月 28日 土曜日 16:54:09 JST
+File: src/hooks/useAudio.test.ts
+Phase: RED
+Tests run: 5
+Failed: 1
+Overall: FAIL → fix required
+
+## 2026年  2月 28日 土曜日 16:54:24 JST
+File: src/hooks/useAudio.ts
+Phase: GREEN
+Tests run: 5
+Failed: 0
+Overall: PASS → ready for next
+
+## 2026年  2月 28日 土曜日 17:03:03 JST
+File: src/hooks/useAudio.test.ts
+Phase: RED
+Tests run: 5
+Failed: 1
+Overall: FAIL → fix required
+
+## 2026年  2月 28日 土曜日 17:03:34 JST
+File: src/hooks/useAudio.test.ts
+Phase: RED
+Tests run: 6
+Failed: 1
+Overall: FAIL → fix required
+
+## 2026年  2月 28日 土曜日 17:03:56 JST
+File: src/hooks/useAudio.ts
+Phase: GREEN
+Tests run: 6
+Failed: 0
+Overall: PASS → ready for next

--- a/src/hooks/useAudio.test.ts
+++ b/src/hooks/useAudio.test.ts
@@ -1,0 +1,235 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useAudio } from './useAudio'
+
+/**
+ * ACCEPTANCE_CRITERIA
+ * 
+ * 1. Web Speech API should correctly capture final transcripts and only trigger onTranscript for final results.
+ * 2. It should trigger onTranscript with the remaining interim transcript when manually stopped via stopRecording().
+ * 3. The SpeechRecognition instance should correctly restart when it ends, without picking up a stale state.isRecording closure.
+ * 4. It should silently retry on a 'network' error to handle transient connection issues.
+ * 5. It should notify onError on non-network errors.
+ * 6. It should debounce identical final transcripts to prevent duplicate messages.
+ */
+
+// Track instances
+let mockInstances: any[] = []
+
+// Mock SpeechRecognition
+class MockSpeechRecognition {
+    continuous = false
+    interimResults = false
+    lang = ''
+    onresult: any = null
+    onerror: any = null
+    onend: any = null
+
+    start = vi.fn()
+    stop = vi.fn()
+
+    constructor() {
+        mockInstances.push(this)
+    }
+}
+
+describe('useAudio', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockInstances = []
+        vi.stubGlobal('SpeechRecognition', MockSpeechRecognition)
+        vi.stubGlobal('webkitSpeechRecognition', MockSpeechRecognition)
+    })
+
+    it('triggers onTranscript with final results only', () => {
+        const onTranscript = vi.fn()
+        const { result } = renderHook(() => useAudio({ onTranscript }))
+
+        act(() => {
+            result.current.startRecording()
+        })
+
+        const recognition = mockInstances[0]
+
+        // Send an interim result
+        act(() => {
+            recognition.onresult({
+                resultIndex: 0,
+                results: [
+                    [{ transcript: 'hello' }, { isFinal: false }]
+                ]
+            } as any)
+        })
+
+        // Expect onTranscript NOT to be called
+        expect(onTranscript).not.toHaveBeenCalled()
+        expect(result.current.transcript).toBe('hello')
+
+        // Send a final result
+        act(() => {
+            recognition.onresult({
+                resultIndex: 0,
+                results: [
+                    Object.assign([{ transcript: 'hello world' }], { isFinal: true })
+                ]
+            } as any)
+        })
+
+        // Expect onTranscript TO BE called
+        expect(onTranscript).toHaveBeenCalledWith('hello world')
+    })
+
+    it('triggers onTranscript with remaining transcript when manually stopped', () => {
+        const onTranscript = vi.fn()
+        const { result } = renderHook(() => useAudio({ onTranscript }))
+
+        act(() => {
+            result.current.startRecording()
+        })
+
+        const recognition = mockInstances[0]
+
+        // Send an interim result
+        act(() => {
+            recognition.onresult({
+                resultIndex: 0,
+                results: [
+                    Object.assign([{ transcript: 'pending text' }], { isFinal: false })
+                ]
+            } as any)
+        })
+
+        // Manually stop
+        act(() => {
+            const returned = result.current.stopRecording()
+            expect(returned).toBe('pending text')
+        })
+
+        // Expect onTranscript to have been called with the pending text
+        expect(onTranscript).toHaveBeenCalledWith('pending text')
+    })
+
+    it('restarts recognition via onend using fresh state', () => {
+        const { result } = renderHook(() => useAudio({ onTranscript: vi.fn() }))
+
+        act(() => {
+            result.current.startRecording()
+        })
+
+        const recognition = mockInstances[0]
+
+        expect(recognition.start).toHaveBeenCalledTimes(1)
+
+        // Trigger onend while allegedly recording
+        act(() => {
+            recognition.onend()
+        })
+
+        // Expect it to have restarted
+        expect(recognition.start).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries on network error instead of failing immediately', async () => {
+        vi.useFakeTimers()
+        const onError = vi.fn()
+        const { result } = renderHook(() => useAudio({ onError }))
+
+        act(() => {
+            result.current.startRecording()
+        })
+
+        const recognition = mockInstances[0]
+
+        expect(result.current.isRecording).toBe(true)
+
+        // Trigger a network error
+        act(() => {
+            recognition.onerror({ error: 'network' } as any)
+        })
+
+        // Should NOT have called onError prop
+        expect(onError).not.toHaveBeenCalled()
+        // Should STILL be reporting as recording to the UI
+        expect(result.current.isRecording).toBe(true)
+
+        // Fast forward the retry timeout (1000ms)
+        act(() => {
+            vi.advanceTimersByTime(1100)
+        })
+
+        // Should have attempted to start again
+        expect(recognition.start).toHaveBeenCalledTimes(2)
+
+        vi.useRealTimers()
+    })
+
+    it('calls onError on non-network errors and stops recording', () => {
+        const onError = vi.fn()
+        const { result } = renderHook(() => useAudio({ onError }))
+
+        act(() => {
+            result.current.startRecording()
+        })
+
+        const recognition = mockInstances[0]
+
+        // Trigger a not-allowed error
+        act(() => {
+            recognition.onerror({ error: 'not-allowed' } as any)
+        })
+
+        // Should have called onError
+        expect(onError).toHaveBeenCalledWith(expect.any(Error))
+        expect(onError.mock.calls[0][0].message).toBe('not-allowed')
+
+        // Should have stopped recording
+        expect(result.current.isRecording).toBe(false)
+    })
+
+    it('debounces identical final transcripts', () => {
+        const onTranscript = vi.fn()
+        const { result } = renderHook(() => useAudio({ onTranscript }))
+
+        act(() => {
+            result.current.startRecording()
+        })
+
+        const recognition = mockInstances[0]
+
+        // Send a final result
+        act(() => {
+            recognition.onresult({
+                resultIndex: 0,
+                results: [
+                    Object.assign([{ transcript: 'duplicate text' }], { isFinal: true })
+                ]
+            } as any)
+        })
+
+        expect(onTranscript).toHaveBeenCalledTimes(1)
+
+        // Stop manually immediately after with the same pending text (simulating the double trigger bug)
+        act(() => {
+            recognition.onresult({
+                resultIndex: 0,
+                results: [
+                    Object.assign([{ transcript: 'duplicate text' }], { isFinal: false })
+                ]
+            } as any)
+            result.current.stopRecording()
+        })
+
+        // Exhaustive rapid trigger
+        act(() => {
+            recognition.onresult({
+                resultIndex: 0,
+                results: [
+                    Object.assign([{ transcript: 'duplicate text' }], { isFinal: true })
+                ]
+            } as any)
+        })
+
+        // Should still only have called onTranscript once
+        expect(onTranscript).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { elevenlabsClient } from '../api/elevenlabsClient'
 import type { RecordingState } from '../api/types'
 
@@ -10,12 +10,33 @@ interface UseAudioOptions {
 export function useAudio(options: UseAudioOptions = {}) {
   const { onTranscript, onError } = options
 
+  // Refs for callbacks to avoid re-initializing SpeechRecognition
+  const onTranscriptRef = useRef(onTranscript)
+  const onErrorRef = useRef(onError)
+
+  // Ref to debounce identical final transcripts
+  const lastTranscriptRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript
+    onErrorRef.current = onError
+  }, [onTranscript, onError])
+
   // State management
   const [state, setState] = useState<RecordingState>({
     isRecording: false,
     isListening: false,
     transcript: '',
   })
+
+  // Refs for state that's needed in event handlers
+  const isRecordingRef = useRef(state.isRecording)
+  const transcriptRef = useRef(state.transcript)
+
+  useEffect(() => {
+    isRecordingRef.current = state.isRecording
+    transcriptRef.current = state.transcript
+  }, [state.isRecording, state.transcript])
 
   // Ref for Web Speech API
   const recognitionRef = useRef<SpeechRecognition | null>(null)
@@ -47,24 +68,47 @@ export function useAudio(options: UseAudioOptions = {}) {
           }
         }
 
-        // Update display state for interim (for live display)
         const displayTranscript = finalTranscript || interimTranscript
         setState(prev => ({ ...prev, transcript: displayTranscript }))
-        // Only invoke onTranscript callback for FINAL results to avoid duplicate API calls
+
+        // Invoke callback on FINAL results
         if (finalTranscript) {
-          onTranscript?.(finalTranscript.trim())
+          const text = finalTranscript.trim()
+          if (text && text !== lastTranscriptRef.current) {
+            lastTranscriptRef.current = text
+            onTranscriptRef.current?.(text)
+          }
+          setState(prev => ({ ...prev, transcript: '' }))
         }
       }
 
       recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
         console.error('Speech recognition error:', event.error)
+
+        // Handle spurious network errors by retrying under the hood
+        if (event.error === 'network' && isRecordingRef.current) {
+          console.warn('Network error encountered, attempting to reconnect in 1s...')
+          // We do NOT set isRecording: false here so the UI doesn't drop
+          setTimeout(() => {
+            if (isRecordingRef.current && recognitionRef.current) {
+              try {
+                recognitionRef.current.start()
+              } catch (e) { /* ignore */ }
+            }
+          }, 1000)
+          return
+        }
+
         setState(prev => ({ ...prev, isRecording: false, isListening: false }))
-        onError?.(new Error(event.error))
+        onErrorRef.current?.(new Error(event.error))
       }
 
       recognition.onend = () => {
-        if (state.isRecording) {
-          recognition.start()
+        // Use the ref to capture the latest state without closure pitfalls
+        if (isRecordingRef.current) {
+          try {
+            recognitionRef.current?.start()
+          } catch (e) { /* ignore already started error */ }
         }
       }
 
@@ -78,58 +122,66 @@ export function useAudio(options: UseAudioOptions = {}) {
         recognitionRef.current.stop()
       }
     }
-  }, [state.isRecording, onTranscript, onError])
+  }, []) // Empty dependency array ensures it's not torn down prematurely
 
   /**
    * Start recording audio and transcribing to text
    */
-  const startRecording = () => {
+  const startRecording = useCallback(() => {
     if (!recognitionRef.current) {
-      onError?.(new Error('Speech recognition not supported'))
+      onErrorRef.current?.(new Error('Speech recognition not supported'))
       return false
     }
 
     try {
       recognitionRef.current.start()
-      setState(prev => ({ ...prev, isRecording: true, isListening: true }))
+      lastTranscriptRef.current = null // Reset debounce tracker on new recording
+      setState(prev => ({ ...prev, isRecording: true, isListening: true, transcript: '' }))
       return true
     } catch (error) {
       console.error('Failed to start recording:', error)
-      onError?.(error instanceof Error ? error : new Error('Failed to start recording'))
+      onErrorRef.current?.(error instanceof Error ? error : new Error('Failed to start recording'))
       return false
     }
-  }
+  }, [])
 
   /**
    * Stop recording and return the transcript
    */
-  const stopRecording = () => {
+  const stopRecording = useCallback(() => {
     if (recognitionRef.current) {
       recognitionRef.current.stop()
       setState(prev => ({ ...prev, isRecording: false, isListening: false }))
+
+      // If we manually stopped, we might have some pending transcript
+      const pendingText = transcriptRef.current.trim()
+      if (pendingText && pendingText !== lastTranscriptRef.current) {
+        lastTranscriptRef.current = pendingText
+        onTranscriptRef.current?.(pendingText)
+      }
     }
-    return state.transcript
-  }
+    return transcriptRef.current
+  }, [])
 
   /**
    * Play text as speech using ElevenLabs
    */
-  const playText = async (text: string, turn: number = 1) => {
+  const playText = useCallback(async (text: string, turn: number = 1) => {
     try {
       await elevenlabsClient.playAudio(text, turn)
     } catch (error) {
       console.error('Failed to play audio:', error)
-      onError?.(error instanceof Error ? error : new Error('Failed to play audio'))
+      onErrorRef.current?.(error instanceof Error ? error : new Error('Failed to play audio'))
       throw error
     }
-  }
+  }, [])
 
   /**
    * Check if browser supports speech recognition
    */
-  const isSpeechRecognitionSupported = () => {
+  const isSpeechRecognitionSupported = useCallback(() => {
     return 'webkitSpeechRecognition' in window || 'SpeechRecognition' in window
-  }
+  }, [])
 
   return {
     // State

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,18 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      // When running npm run dev (Vite), proxy /api to the local Vercel server (vercel dev)
+      // Note: You must run `vercel dev` in a separate terminal OR we map Vite as the frontend explicitly.
+      // Usually, `vercel dev` takes over the frontend completely on port 3000, but if you access Vite directly on 5173, it needs this:
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        secure: false,
+      }
+    }
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
Closes #13

**Bug Fixes:**
- Resolves an issue where `useAudio` was referencing a stale closure in the `onend` handler preventing  from restarting.
- Prevents `useEffect` re-renders from prematurely tearing down the speech recognition object, allowing it to capture final transcripts.
- Adds a robust 1-second backoff retry mechanism for transient `network` errors in Chrome.
- Mitigates duplicate message submissions by debouncing rapidly firing contiguous matching transcripts.
- Updates `vite.config.ts` to easily proxy local frontend Vite requests to Vercel dev API routes port 3000 avoiding `404` errors.

**Testing:**
- TDD tests added for `useAudio.ts` successfully validate all corner cases and error retries natively.