### PR TITLE
Fix/Issue-21 Transition to Image Upload

### DIFF
--- a/.artifacts/tdd-cycle-status.md
+++ b/.artifacts/tdd-cycle-status.md
@@ -377,3 +377,26 @@ Tests run: 7
 Failed: None
 Overall: PASS → ready for next
 
+
+## 2026-02-28T12:00:05Z
+File: src/hooks/useConversation.ts
+Phase: GREEN
+Tests run: 1
+Failed: []
+Overall: PASS → ready for next
+
+## 2026-02-28T12:00:05Z
+File: src/App.tsx
+Phase: GREEN
+Tests run: 6
+Failed: []
+Overall: PASS → ready for next
+
+
+## 2026-02-28T12:01:46Z
+File: src/components/EndMessageOverlay.tsx
+Phase: GREEN
+Tests run: 3
+Failed: []
+Overall: PASS → ready for next
+

--- a/docs/mvp/integration/end_turn.spec.md
+++ b/docs/mvp/integration/end_turn.spec.md
@@ -16,5 +16,7 @@ This specification covers the integration of the 7th turn end flow. When the con
    - A concluding message ("7ターンが終了しました。手書きの振り返りをアップロードしてください") is visually presented.
 
 3. **Upload UI Access:**
-   - Inside or alongside the `EndMessageOverlay`, the `UploadArea` component is visible, allowing the user to select or drag-and-drop an image file.
+   - The `EndMessageOverlay` displays an "Upload Card" button (formerly "Restart").
+   - Clicking the button sets `isWaitingVision` to `true`, hiding the overlay and displaying the `UploadArea`.
+   - The user can then select or drag-and-drop an image file.
    - The conversation log remains visible in the background for reference.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -99,17 +99,37 @@ describe('App Integration', () => {
     })
 
     describe('End Turn Flow', () => {
-        it('shows EndMessageOverlay and UploadArea on 7th turn', () => {
+        it('shows EndMessageOverlay and then UploadArea when user clicks Upload Card button', () => {
             mockUseConversation.turns = 7
             mockUseConversation.isSessionEnded = true
 
-            render(<App />)
+            const { rerender } = render(<App />)
 
             // Should show end message
             expect(screen.getByText(/Your 7 turns are complete/)).toBeInTheDocument()
             // MicButton should be disabled
             const micButton = screen.getByRole('button', { name: /Start recording/i })
             expect(micButton).toBeDisabled()
+
+            // Upload button should be there
+            const uploadButton = screen.getByRole('button', { name: /Upload Card/i })
+            expect(uploadButton).toBeInTheDocument()
+
+            // UploadArea should not be there initially
+            expect(screen.queryByTestId('upload-input')).not.toBeInTheDocument()
+
+            // Click the upload card transition button
+            fireEvent.click(uploadButton)
+
+            // Simulate the state change triggered by startVisionUpload
+            mockUseConversation.isWaitingVision = true
+            rerender(<App />)
+
+            // Now UploadArea should be visible
+            expect(screen.getByTestId('upload-input')).toBeInTheDocument()
+
+            // EndMessageOverlay should be hidden
+            expect(screen.queryByText(/Your 7 turns are complete/)).not.toBeInTheDocument()
         })
     })
 
@@ -126,6 +146,14 @@ describe('App Integration', () => {
                 feedback: 'Great reflection!'
             })
 
+            render(<App />)
+
+            // Click the new transition button
+            const uploadButton = screen.getByRole('button', { name: /Upload Card/i })
+            fireEvent.click(uploadButton)
+
+            // Simulate the state change triggered by startVisionUpload
+            mockUseConversation.isWaitingVision = true
             render(<App />)
 
             const fileInput = screen.getByTestId('upload-input')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,10 @@ function App() {
     turns,
     history,
     isSessionEnded,
+    isWaitingVision,
     addMessage,
-    resumeSessionWithVision
+    resumeSessionWithVision,
+    startVisionUpload
   } = useConversation()
 
   // Fix 2: loading and error state
@@ -136,20 +138,23 @@ function App() {
       {/* Fix 3: EndMessageOverlay is always a non-blocking banner, UploadArea is always rendered below it */}
       {isSessionEnded && (
         <div className="w-full flex flex-col gap-4">
-          <EndMessageOverlay
-            isVisible={true}
-            message="Your 7 turns are complete. Please upload a photo of your handwritten reflection."
-            onRestart={() => { }}
-          />
-          <div className="w-full">
-            {isUploading ? (
-              <div aria-live="polite" className="text-center text-sm text-gray-500 animate-pulse py-4">
-                Analyzing image…
-              </div>
-            ) : (
-              <UploadArea onImageSelect={handleUpload} />
-            )}
-          </div>
+          {!isWaitingVision ? (
+            <EndMessageOverlay
+              isVisible={true}
+              message="Your 7 turns are complete. Please upload a photo of your handwritten reflection."
+              onUploadTransition={startVisionUpload}
+            />
+          ) : (
+            <div className="w-full">
+              {isUploading ? (
+                <div aria-live="polite" className="text-center text-sm text-gray-500 animate-pulse py-4">
+                  Analyzing image…
+                </div>
+              ) : (
+                <UploadArea onImageSelect={handleUpload} />
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/EndMessageOverlay.test.tsx
+++ b/src/components/EndMessageOverlay.test.tsx
@@ -4,22 +4,22 @@ import { EndMessageOverlay } from './EndMessageOverlay'
 
 describe('EndMessageOverlay', () => {
     it('renders nothing when isVisible is false', () => {
-        const { container } = render(<EndMessageOverlay isVisible={false} message="Game Over" onRestart={vi.fn()} />)
+        const { container } = render(<EndMessageOverlay isVisible={false} message="Game Over" onUploadTransition={vi.fn()} />)
         expect(container).toBeEmptyDOMElement()
     })
 
     it('renders overlay and message when isVisible is true', () => {
-        render(<EndMessageOverlay isVisible={true} message="Game Over" onRestart={vi.fn()} />)
+        render(<EndMessageOverlay isVisible={true} message="Game Over" onUploadTransition={vi.fn()} />)
         expect(screen.getByText('Game Over')).toBeInTheDocument()
     })
 
-    it('triggers onRestart when the button is clicked', () => {
-        const handleRestart = vi.fn()
-        render(<EndMessageOverlay isVisible={true} message="Game Over" onRestart={handleRestart} />)
+    it('triggers onUploadTransition when the button is clicked', () => {
+        const handleTransition = vi.fn()
+        render(<EndMessageOverlay isVisible={true} message="Game Over" onUploadTransition={handleTransition} />)
 
-        const button = screen.getByRole('button', { name: /restart/i })
+        const button = screen.getByRole('button', { name: /upload card/i })
         fireEvent.click(button)
 
-        expect(handleRestart).toHaveBeenCalledTimes(1)
+        expect(handleTransition).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/components/EndMessageOverlay.tsx
+++ b/src/components/EndMessageOverlay.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { RefreshCw } from 'lucide-react';
+import { Upload } from 'lucide-react';
 
 export interface EndMessageOverlayProps {
     isVisible: boolean;
     message: string;
-    onRestart: () => void;
+    onUploadTransition: () => void;
 }
 
 export const EndMessageOverlay: React.FC<EndMessageOverlayProps> = ({
     isVisible,
     message,
-    onRestart,
+    onUploadTransition,
 }) => {
     if (!isVisible) return null;
 
@@ -25,12 +25,12 @@ export const EndMessageOverlay: React.FC<EndMessageOverlayProps> = ({
                 </p>
 
                 <button
-                    onClick={onRestart}
+                    onClick={onUploadTransition}
                     className="flex items-center justify-center space-x-2 w-full py-4 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-all hover:scale-[1.02] active:scale-95 shadow-lg shadow-blue-600/30"
-                    aria-label="Restart session"
+                    aria-label="Upload Card"
                 >
-                    <RefreshCw className="w-5 h-5" />
-                    <span>Restart</span>
+                    <Upload className="w-5 h-5" />
+                    <span>Upload Card</span>
                 </button>
             </div>
         </div>

--- a/src/hooks/useConversation.test.ts
+++ b/src/hooks/useConversation.test.ts
@@ -121,4 +121,26 @@ describe('useConversation', () => {
         expect(result.current.history).toHaveLength(2)
         expect(result.current.history[1]).toEqual({ role: 'assistant', content: 'Great picture!' })
     })
+
+    it('sets isWaitingVision to true when startVisionUpload is called', () => {
+        vi.spyOn(localStorageImpl, 'getSession').mockReturnValue({
+            id: 'mock-id',
+            turns: 7,
+            history: [{ role: 'user', content: 'hello' }],
+            isSessionEnded: true,
+            isWaitingVision: false
+        })
+
+        const { result } = renderHook(() => useConversation())
+
+        expect(result.current.isWaitingVision).toBe(false)
+
+        act(() => {
+            result.current.startVisionUpload()
+        })
+
+        expect(result.current.isWaitingVision).toBe(true)
+        // isSessionEnded should remain true or at least not interrupt the UI flow
+        expect(result.current.isSessionEnded).toBe(true)
+    })
 })

--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -83,9 +83,17 @@ export const useConversation = () => {
         });
     };
 
+    const startVisionUpload = () => {
+        setState((prevState) => ({
+            ...prevState,
+            isWaitingVision: true
+        }));
+    };
+
     return {
         ...state,
         addMessage,
-        resumeSessionWithVision
+        resumeSessionWithVision,
+        startVisionUpload
     };
 };


### PR DESCRIPTION
Resolves #21\n\nThis PR fixes the issue where the user is unable to transition to the Upload UI at the end of a session.\n\nChanges Made:\n- Updated `EndMessageOverlay` to change the "Restart" button to "Upload Card"\n- Modified `App.tsx` to show `UploadArea` instead of the overlay once the button is clicked.\n- Added `startVisionUpload` transition method to `useConversation`\n- Adhered to strict TDD by updating tests (`useConversation.test.ts`, `App.test.tsx`, `EndMessageOverlay.test.tsx`)