### PR TITLE
Fix payload too large error by compressing images before upload

### DIFF
--- a/.artifacts/tdd-cycle-status.md
+++ b/.artifacts/tdd-cycle-status.md
@@ -377,3 +377,15 @@ Tests run: 7
 Failed: None
 Overall: PASS → ready for next
 
+## 2026-03-01T01:03:13+09:00
+File: src/lib/imageUtils.ts
+Phase: GREEN
+Tests run: 2
+Failed: none
+Overall: PASS → ready for next
+## 2026-03-01T01:04:35+09:00
+File: src/App.tsx
+Phase: GREEN
+Tests run: 99
+Failed: none
+Overall: PASS → ready for next

--- a/docs/mvp/spec/image_compression.spec.md
+++ b/docs/mvp/spec/image_compression.spec.md
@@ -1,0 +1,17 @@
+# Image Compression Spec
+
+## Objective
+To prevent the `FUNCTION_PAYLOAD_TOO_LARGE` error when uploading images to the Vision API, we must compress and resize images on the client side before base64 encoding them.
+
+## Context
+When a user uploads a high-resolution photo (e.g., from a mobile device), the file size can easily exceed Vercel's 4.5MB Serverless Function payload limit once base64 encoded. The Mistral Pixtral-12b model also performs optimally and uses fewer tokens with images sized at 1024x1024 or smaller.
+
+## ACCEPTANCE_CRITERIA
+- [ ] AC-1: Images are resized to a maximum dimension (e.g. 1024x1024) while preserving aspect ratio.
+- [ ] AC-2: Images are converted to JPEG format.
+- [ ] AC-3: Images are compressed to reduce file size (e.g., quality 0.8).
+- [ ] AC-4: A standard `.test.ts` file exists for the `compressImage` utility and is passing.
+- [ ] AC-5: `App.tsx` handles `onImageSelect` by calling `compressImage` before base64 encoding and sending the payload.
+
+## Non-Functional Requirements
+- Ensure TDD is strictly followed for the `src/lib/imageUtils.ts` integration.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -13,6 +13,9 @@ vi.mock('./hooks/useConversation')
 vi.mock('./hooks/useAudio')
 vi.mock('./api/mistralClient')
 vi.mock('./api/elevenlabsClient')
+vi.mock('./lib/imageUtils', () => ({
+    compressImage: vi.fn().mockResolvedValue('mock-base64-image-data'),
+}))
 
 describe('App Integration', () => {
     let mockUseConversation: any
@@ -155,7 +158,10 @@ describe('App Integration', () => {
 
             // It should call mistralClient.vision
             await waitFor(() => {
-                expect(mistralClient.vision).toHaveBeenCalled()
+                expect(mistralClient.vision).toHaveBeenCalledWith({
+                    image: 'data:image/jpeg;base64,mock-base64-image-data',
+                    messages: expect.any(Array)
+                })
             })
 
             // It should call resumeSessionWithVision

--- a/src/lib/imageUtils.test.ts
+++ b/src/lib/imageUtils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { compressImage } from './imageUtils';
+
+describe('compressImage', () => {
+    beforeEach(() => {
+        // Mock URL.createObjectURL and URL.revokeObjectURL
+        global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+        global.URL.revokeObjectURL = vi.fn();
+    });
+
+    it('should resolve with a base64 string', async () => {
+        // We cannot easily test canvas drawImage in vitest without jsdom-canvas
+        // So we'll test the error handling or mock the Image object to instantly resolve
+
+        // Mock global Image constructor to trigger onload
+        const originalImage = global.Image;
+        global.Image = class {
+            onload: () => void = () => { };
+            src: string = '';
+            width: number = 2000;
+            height: number = 1000;
+
+            constructor() {
+                setTimeout(() => this.onload(), 0);
+            }
+        } as any;
+
+        try {
+            const file = new File(['dummy content'], 'test.jpg', { type: 'image/jpeg' });
+            // This will throw if canvas is not implemented in jsdom, but we'll catch it or mock it
+            // Let's mock document.createElement('canvas')
+            const mockContext = {
+                drawImage: vi.fn(),
+            };
+            const mockCanvas = {
+                width: 0,
+                height: 0,
+                getContext: vi.fn(() => mockContext),
+                toDataURL: vi.fn(() => 'data:image/jpeg;base64,mockbase64data'),
+            };
+            vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+                if (tagName === 'canvas') return mockCanvas as any;
+                return document.createElement(tagName);
+            });
+
+            const result = await compressImage(file, 1024);
+
+            expect(result).toBe('mockbase64data'); // Expects the base64 content without the prefix
+            expect(mockCanvas.width).toBe(1024); // Width should be scaled down
+            expect(mockCanvas.height).toBe(512); // Height scaled proportionally
+            expect(mockContext.drawImage).toHaveBeenCalled();
+        } finally {
+            global.Image = originalImage;
+            vi.restoreAllMocks();
+        }
+    });
+
+    it('should reject if file is not an image', async () => {
+        const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+        await expect(compressImage(file)).rejects.toThrow('File must be an image');
+    });
+});

--- a/src/lib/imageUtils.ts
+++ b/src/lib/imageUtils.ts
@@ -1,0 +1,61 @@
+/**
+ * Compresses an image file by resizing its maximum dimension.
+ * @param file The image file to compress.
+ * @param maxSize The maximum width or height of the compressed image.
+ * @returns A promise that resolves to the compressed image as a base64 string.
+ */
+export const compressImage = (file: File, maxSize: number = 1024): Promise<string> => {
+    return new Promise((resolve, reject) => {
+        if (!file.type.startsWith('image/')) {
+            return reject(new Error('File must be an image'));
+        }
+
+        const img = new Image();
+        const url = URL.createObjectURL(file);
+
+        img.onload = () => {
+            URL.revokeObjectURL(url); // Clean up the URL object
+
+            let width = img.width;
+            let height = img.height;
+
+            // Calculate new dimensions while maintaining aspect ratio
+            if (width > maxSize || height > maxSize) {
+                if (width > height) {
+                    height = Math.round((height * maxSize) / width);
+                    width = maxSize;
+                } else {
+                    width = Math.round((width * maxSize) / height);
+                    height = maxSize;
+                }
+            }
+
+            // Create a canvas to draw the resized image
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+
+            const ctx = canvas.getContext('2d');
+            if (!ctx) {
+                return reject(new Error('Could not get 2d context from canvas'));
+            }
+
+            // Draw image onto canvas
+            ctx.drawImage(img, 0, 0, width, height);
+
+            // Convert canvas to a base64 string (JPEG format with 0.8 quality)
+            const dataUrl = canvas.toDataURL('image/jpeg', 0.8);
+
+            // Resolve with only the base64 payload (strip the data prefix)
+            const base64Content = dataUrl.split(',')[1] || dataUrl;
+            resolve(base64Content);
+        };
+
+        img.onerror = () => {
+            URL.revokeObjectURL(url);
+            reject(new Error('Failed to load image for compression'));
+        };
+
+        img.src = url;
+    });
+};


### PR DESCRIPTION
Resolves #26 by resizing images on the client side to a max dimension of 1024px before sending them to the Mistral Vision API.