### PR TITLE
fix: mute microphone on upload phase and fix config values

### DIFF
--- a/.artifacts/tdd-cycle-status.md
+++ b/.artifacts/tdd-cycle-status.md
@@ -413,3 +413,15 @@ Phase: GREEN
 Tests run: 100
 Failed: 0
 Overall: PASS → ready for next
+## 2026-03-01T02:02:06+09:00
+File: src/App.test.tsx
+Phase: RED
+Tests run: 1
+Failed: shows EndMessageOverlay and UploadArea on 7th turn and stops recording
+Overall: FAIL -> fix required
+## 2026-03-01T02:02:58+09:00
+File: src/App.tsx, src/lib/featureFlags.ts
+Phase: GREEN
+Tests run: 2
+Failed: none
+Overall: PASS -> ready for next

--- a/docs/mvp/spec/app_flow.spec.md
+++ b/docs/mvp/spec/app_flow.spec.md
@@ -1,0 +1,12 @@
+# App Flow Specification
+
+This document defines the acceptance criteria for high-level App component flow and application configuration logic.
+
+## ACCEPTANCE_CRITERIA
+
+### featureFlags.ts
+- `getConfigValue` and `getFeatureFlag` MUST access `import.meta.env` using static property references (e.g., `import.meta.env.VITE_MAX_TURNS`) because Vite's string replacement does not support dynamic keys.
+
+### App.tsx
+- When the conversation reaches the turn limit (i.e., `isSessionEnded` becomes true) or when the user enters the upload phase (`isWaitingVision` becomes true), the application MUST automatically stop recording voice input.
+- The `stopRecording` function must be called to ensure the microphone stream is properly closed and the browser's recording indicator turns off.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -104,7 +104,12 @@ describe('App Integration', () => {
     })
 
     describe('End Turn Flow', () => {
-        it('shows EndMessageOverlay and UploadArea on 7th turn', () => {
+        it('shows EndMessageOverlay and UploadArea on 7th turn and stops recording', () => {
+            // Setup initial state: User is recording right before turn 7
+            mockUseAudio.isRecording = true
+            vi.mocked(useAudio).mockReturnValue(mockUseAudio)
+
+            // Simulate transition to turn 7
             mockUseConversation.turns = 7
             mockUseConversation.isSessionEnded = true
 
@@ -112,9 +117,13 @@ describe('App Integration', () => {
 
             // Should show end message
             expect(screen.getByText(/Your 7 turns are complete/)).toBeInTheDocument()
+
             // MicButton should be disabled
-            const micButton = screen.getByRole('button', { name: /Start recording/i })
+            const micButton = screen.getByRole('button', { name: /recording/i })
             expect(micButton).toBeDisabled()
+
+            // stopRecording MUST be called to turn off microphone automatically
+            expect(mockUseAudio.stopRecording).toHaveBeenCalled()
         })
     })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useConversation } from './hooks/useConversation'
 import { useAudio } from './hooks/useAudio'
 import { mistralClient } from './api/mistralClient'
@@ -124,6 +124,13 @@ function App() {
       startRecording()
     }
   }
+
+  // Force stop recording if we enter the end of session or upload phase
+  useEffect(() => {
+    if ((isSessionEnded || isWaitingVision) && isRecording) {
+      stopRecording()
+    }
+  }, [isSessionEnded, isWaitingVision, isRecording, stopRecording])
 
   return (
     <div className="app-container max-w-2xl mx-auto p-4 flex flex-col items-center gap-6">

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -31,7 +31,10 @@ function getFeatureFlag(flagName: keyof FeatureFlags): boolean {
   // Check import.meta.env (Vite's way of accessing environment variables)
   // Environment variables must be prefixed with VITE_ to be exposed to client-side code
   if (typeof import.meta !== 'undefined' && import.meta.env) {
-    const envValue = import.meta.env[`VITE_${flagName}`]
+    let envValue: string | undefined
+    if (flagName === 'ENABLE_VISION_FALLBACK') {
+      envValue = import.meta.env.VITE_ENABLE_VISION_FALLBACK
+    }
     if (envValue !== undefined) {
       return envValue === 'true' || envValue === '1'
     }
@@ -79,7 +82,10 @@ export function isFeatureEnabled(flagName: keyof FeatureFlags): boolean {
 function getConfigValue(configName: keyof AppConfig): number {
   // Check import.meta.env (Vite's way of accessing environment variables)
   if (typeof import.meta !== 'undefined' && import.meta.env) {
-    const envValue = import.meta.env[`VITE_${configName}`]
+    let envValue: string | undefined
+    if (configName === 'MAX_TURNS') {
+      envValue = import.meta.env.VITE_MAX_TURNS
+    }
     if (envValue !== undefined) {
       const parsed = parseInt(envValue, 10)
       if (!isNaN(parsed) && parsed > 0) {


### PR DESCRIPTION
Fixes #38

- Stops microphone recording when a session ends or enters upload phase to avoid capturing unused audio.
- Replaces dynamic Vite `import.meta.env` keys with hardcoded strings to fix environment variable processing.